### PR TITLE
Bump go-task from 3.37.2 to 3.43.2

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -31,8 +31,7 @@
     "init_hook": [
       "export GOBIN=$(git rev-parse --show-toplevel)/bin",
       "export PATH=$GOBIN:$PATH",
-      "go install sigs.k8s.io/cloud-provider-kind@v0.2.0",
-      "eval \"$(task --completion zsh)\""
+      "go install sigs.k8s.io/cloud-provider-kind@v0.2.0"
     ],
     "scripts": {
       "test": ["echo \"Error: no test specified\" && exit 1"]


### PR DESCRIPTION
Bumps to a version of go-task that supports completions (which are mentioned in the course).

Resolves #19 
- https://github.com/sidpalas/devops-directive-kubernetes-course/issues/19#issuecomment-2919695289