### PR TITLE
Fix postgres bitnami confict for deployment stage

### DIFF
--- a/07-deploying-demo-application/postgresql/Taskfile.yaml
+++ b/07-deploying-demo-application/postgresql/Taskfile.yaml
@@ -2,6 +2,10 @@ version: "3"
 
 tasks:
   install-postgres:
+    # Note: The Bitnami Helm chart for PostgreSQL was previously used here.
+    # It was replaced with a direct Kubernetes manifest because Bitnami’s charts
+    # and container images are no longer freely accessible for public use.
+    # The manifest now uses the official postgres:16 image from Docker Hub.
     desc: "Deploy PostgreSQL using direct Kubernetes manifests"
     cmds:
       - kubectl create namespace postgres --dry-run=client -o yaml | kubectl apply -f -

--- a/07-deploying-demo-application/postgresql/Taskfile.yaml
+++ b/07-deploying-demo-application/postgresql/Taskfile.yaml
@@ -2,17 +2,10 @@ version: "3"
 
 tasks:
   install-postgres:
-    desc: "Deploy PostgreSQL using Helm"
+    desc: "Deploy PostgreSQL using direct Kubernetes manifests"
     cmds:
-      - helm repo add bitnami https://charts.bitnami.com/bitnami
-      - |
-        helm upgrade --install \
-          -n postgres \
-          postgres bitnami/postgresql \
-          --set auth.postgresPassword=foobarbaz \
-          --version 15.3.2 \
-          --values values.yaml \
-          --create-namespace
+      - kubectl create namespace postgres --dry-run=client -o yaml | kubectl apply -f -
+      - kubectl apply -f postgres-simple.yaml
 
   apply-initial-db-migration-job:
     desc: "Run init.sql script against the DB"

--- a/07-deploying-demo-application/postgresql/postgres-simple.yaml
+++ b/07-deploying-demo-application/postgresql/postgres-simple.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-postgresql
+  namespace: postgres
+spec:
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: postgres
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-postgresql
+  namespace: postgres
+spec:
+  serviceName: postgres-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POSTGRES_PASSWORD
+          value: foobarbaz
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi

--- a/07-deploying-demo-application/postgresql/values.yaml
+++ b/07-deploying-demo-application/postgresql/values.yaml
@@ -1,9 +1,0 @@
-primary:
-  resources:
-    limits:
-      ephemeral-storage: 1Gi
-      memory: 500Mi
-    requests:
-      cpu: 100m
-      ephemeral-storage: 50Mi
-      memory: 128Mi


### PR DESCRIPTION
For older version, bitnami used to provide their charts and images free of charge, but has changed recently. 
I updated to replace the Bitnami Helm deployment with a simple manifest that pulls the official postgres:16 image directly from Docker Hub. 
The new config successfully deploys PostgreSQL and seem to work seamlessly with the rest of the demo app. 