### PR TITLE
Ovveride postgreSQL image to use bitnamilegacy for Helm module

### DIFF
--- a/05-helm/postgresql/values.yaml
+++ b/05-helm/postgresql/values.yaml
@@ -1,2 +1,5 @@
 commonAnnotations:
   foo: bar
+
+image:
+  repository: bitnamilegacy/postgresql


### PR DESCRIPTION
Updates values.yaml to use bitnamilegacy image repo to avoid subscription requirements

Resolves #25 

