### PR TITLE
feat: delete task for namespace stuck as terminating

### DIFF
--- a/04-built-in-resource-types/ConfigMap/Taskfile.yaml
+++ b/04-built-in-resource-types/ConfigMap/Taskfile.yaml
@@ -45,3 +45,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+
+  08-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/CronJob/Taskfile.yaml
+++ b/04-built-in-resource-types/CronJob/Taskfile.yaml
@@ -35,3 +35,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  06-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/DaemonSet/Taskfile.yaml
+++ b/04-built-in-resource-types/DaemonSet/Taskfile.yaml
@@ -30,3 +30,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  05-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Deployment/Taskfile.yaml
+++ b/04-built-in-resource-types/Deployment/Taskfile.yaml
@@ -36,3 +36,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  06-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/GatewayAPI/Taskfile.yaml
+++ b/04-built-in-resource-types/GatewayAPI/Taskfile.yaml
@@ -63,3 +63,10 @@ tasks:
         silent: true
       - kubectl delete -f Namespace.yaml
       - kubectl delete ns haproxy-controller
+  
+  07-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Ingress/Taskfile.yaml
+++ b/04-built-in-resource-types/Ingress/Taskfile.yaml
@@ -54,3 +54,10 @@ tasks:
         silent: true
       - kubectl delete -f Namespace.yaml
       - kubectl delete namespace ingress-nginx
+  
+  07-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Job/Taskfile.yaml
+++ b/04-built-in-resource-types/Job/Taskfile.yaml
@@ -35,3 +35,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  06-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Namespace/Taskfile.yaml
+++ b/04-built-in-resource-types/Namespace/Taskfile.yaml
@@ -16,3 +16,10 @@ tasks:
       - kubectl delete namespace 04--namespace-cli
       - kubectl delete -f Namespace.yaml
     desc: Delete the namespace
+  
+  04-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/PersistentVolume/Taskfile.yaml
+++ b/04-built-in-resource-types/PersistentVolume/Taskfile.yaml
@@ -52,3 +52,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  08-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Pod/Taskfile.yaml
+++ b/04-built-in-resource-types/Pod/Taskfile.yaml
@@ -47,3 +47,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  08-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/RBAC/Taskfile.yaml
+++ b/04-built-in-resource-types/RBAC/Taskfile.yaml
@@ -42,3 +42,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  06-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/ReplicaSet/Taskfile.yaml
+++ b/04-built-in-resource-types/ReplicaSet/Taskfile.yaml
@@ -36,3 +36,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+
+  06-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Secret/Taskfile.yaml
+++ b/04-built-in-resource-types/Secret/Taskfile.yaml
@@ -77,3 +77,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  13-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/Service/Taskfile.yaml
+++ b/04-built-in-resource-types/Service/Taskfile.yaml
@@ -42,3 +42,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  07-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/04-built-in-resource-types/StatefulSet/Taskfile.yaml
+++ b/04-built-in-resource-types/StatefulSet/Taskfile.yaml
@@ -42,3 +42,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+
+  06-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/05-helm/charts/Taskfile.yaml
+++ b/05-helm/charts/Taskfile.yaml
@@ -30,3 +30,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  05-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/05-helm/postgresql/Taskfile.yaml
+++ b/05-helm/postgresql/Taskfile.yaml
@@ -104,3 +104,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+
+  17-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/09-deploying-auxiliary-tooling/cloudnative-pg/Taskfile.yaml
+++ b/09-deploying-auxiliary-tooling/cloudnative-pg/Taskfile.yaml
@@ -85,3 +85,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  09-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/10-developer-experience/external-secrets-operator/Taskfile.yaml
+++ b/10-developer-experience/external-secrets-operator/Taskfile.yaml
@@ -5,6 +5,7 @@ env:
   BORDER_FOREGROUND: "212"
   PADDING: "1 1"
   MARGIN: "1 1"
+  NAMESPACE: external-secrets
 
 tasks:
   01-install-external-secrets:
@@ -67,3 +68,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete ns external-secrets
+  
+  09-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'

--- a/11-debugging/Taskfile.yaml
+++ b/11-debugging/Taskfile.yaml
@@ -25,3 +25,10 @@ tasks:
       - cmd: gum style "🚨 Deleting the namespace recursively deletes the resources inside of it! 🚨 "
         silent: true
       - kubectl delete -f Namespace.yaml
+  
+  04-delete-namespace-state-terminating:
+    desc: "Delete the namespace for kubernetes v1 stuck state on terminating"
+    cmds:
+      - cmd: gum style "🚨 Deleting namespace stucked on terminating state for old kubernetes version! 🚨 "
+        silent: true
+      - 'kubectl get namespace ${NAMESPACE} -o json | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/${NAMESPACE}/finalize -f -'


### PR DESCRIPTION
I use kubernetes version 1.34 and i found problems to delete namespace. The namespace stuck as terminating state, and never terminating, so i found this soluton to solve my problem. I just add another task for namespace stucked on terminating state.