### PR TITLE
fix: remove hardcoded GCP project ID

### DIFF
--- a/03-installation-and-setup/Taskfile.yaml
+++ b/03-installation-and-setup/Taskfile.yaml
@@ -134,7 +134,8 @@ tasks:
   gcp:06-create-cluster:
     desc: "Create GKE cluster"
     vars:
-      GCP_PROJECT_ID: kubernetes-course-424917
+      GCP_PROJECT_ID:
+        sh: gcloud config get-value project 2>/dev/null
     cmds:
       - |
         gcloud container clusters create ${CLUSTER_NAME} \


### PR DESCRIPTION
Problem

The Taskfile.yml in 03-installation-and-setup directory used a hardcoded GCP project ID in the Workload Identity configuration:

--workload-pool=kubernetes-course-424917.svc.id.goog

This only works for the original project.

When another user runs the task with their own GCP project, the cluster creation fails with an error similar to:

Currently, the only supported value for workload pool is "<current-project-id>.svc.id.goog"

This error can be confusing, especially for beginners who are not familiar with YAML, Go Task, or GCP configuration.

Solution

This PR dynamically retrieves the currently configured GCP project ID:

vars:
  GCP_PROJECT_ID:
    sh: gcloud config get-value project 2>/dev/null

The cluster creation command then uses this variable:

--workload-pool={{.GCP_PROJECT_ID}}.svc.id.goog
Result

Each user can now create the cluster in their own GCP project without manually editing the Taskfile.yml.

This makes the configuration:

easier for beginners;
reusable with any GCP project;
less likely to fail because of a hardcoded project ID.
Testing

The following task now uses the active GCP project automatically:

task gcp:06-create-cluster