### PR TITLE
Support for cloud-provider-kind using podman rootless

### DIFF
--- a/03-installation-and-setup/Taskfile.yaml
+++ b/03-installation-and-setup/Taskfile.yaml
@@ -182,6 +182,11 @@ tasks:
     cmds:
       - sudo cloud-provider-kind
 
+  kind:03-run-cloud-provider-kind-rootless:
+    desc: "Run cloud-provider-kind without sudo (rootless Podman workflow)"
+    cmds:
+      - cloud-provider-kind
+
   kind:04-delete-cluster:
     cmds:
       - kind delete cluster


### PR DESCRIPTION
Add rootless Podman workflow for cloud-provider-kind

One needs to avoid using sudo to run cloud-provider-kind when using podman on linux.

Result after starting cloud-provider-kind with this change:
```
$  k get svc
NAME                 TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)        AGE
nginx-loadbalancer   LoadBalancer   10.96.30.2   10.89.0.6     80:32475/TCP   33m
```

Yes, I suppose one could do something fancy and automate the test for whether rootless podman was being used, but that's beyond my time availability.
